### PR TITLE
Detoxifying returned value of get_object method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.0
+
+- Updated returned value format of get_action method from `_ref` to `ref`.
+
 ## 0.1.0
 
 - Initial Release of Infoblox integration

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -41,10 +41,14 @@ class InfobloxConnector(connector.Connector):
         The original method returns dict value that st2 doens't take care (e.g. '_ref'
         key-value pairs). This method interchanges this key to another harmless one.
         """
-        # The get_object method of infoblox-client returns list of Infoblox objects
         results = super(InfobloxConnector, self).get_object(*args, **kwargs)
 
-        return [self._inspect_and_interchane_dict(x) for x in results]
+        # The get_object method of infoblox-client returns list of Infoblox objects.
+        # But when there is no Infoblox object to be returned, this method returns None.
+        if isinstance(results, list):
+            return [self._inspect_and_interchane_dict(x) for x in results]
+        else:
+            return results
 
 
 class InfobloxBaseAction(Action):

--- a/actions/restart_services.py
+++ b/actions/restart_services.py
@@ -9,9 +9,9 @@ class RestartAllMemberServicesAction(InfobloxBaseAction):
     def run(self):
         return [self.connection.call_func(**{
             'func_name': 'restartservices',
-            'ref': x['_ref'],
+            'ref': x['ref'],
             'payload': {
                 'restart_option': 'RESTART_IF_NEEDED',
                 'service_option': 'ALL'
             }
-        }) for x in self.connection.get_object('member') if x and '_ref' in x]
+        }) for x in self.connection.get_object('member') if x and 'ref' in x]

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: infoblox
 name: infoblox
 description: Infoblox IPAM, DNS and DHCP management
-version: 1.0.0
+version: 0.3.0
 keywords:
   - IPAM
   - DNS

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: infoblox
 name: infoblox
 description: Infoblox IPAM, DNS and DHCP management
-version: 0.2.0
+version: 1.0.0
 keywords:
   - IPAM
   - DNS

--- a/tests/test_action_get_object.py
+++ b/tests/test_action_get_object.py
@@ -30,6 +30,11 @@ class GetObjectTestCase(InfobloxBaseActionTestCase):
                 # The case '_ref' string values in a list, these are harmless.
                 'raw': [{'fuga': ['_ref', 'foo']}, '_ref'],
                 'exp': [{'fuga': ['_ref', 'foo']}, '_ref'],
+            },
+            {
+                # The case non-list value is returned.
+                'raw': None,
+                'exp': None,
             }
         ]
 

--- a/tests/test_action_get_object.py
+++ b/tests/test_action_get_object.py
@@ -1,0 +1,43 @@
+import mock
+
+from get_object import GetObjectAction
+from tests.lib.action import InfobloxBaseActionTestCase
+
+
+class GetObjectTestCase(InfobloxBaseActionTestCase):
+    __test__ = True
+    action_cls = GetObjectAction
+
+    def test_get_object_that_has_malformed_value(self):
+        action = self.get_action_instance(self.full_config)
+        check_values = [
+            {
+                # The case malformed key is in a top level dict value.
+                'raw': [{'foo': 'bar', '_ref': 'foo'}, {'hoge': 'fuga'}],
+                'exp': [{'foo': 'bar', 'ref': 'foo'}, {'hoge': 'fuga'}]
+            },
+            {
+                # The case malformed key is in a internal dict value.
+                'raw': [{'hoge': {'foo': 'bar', '_ref': 'bar'}}],
+                'exp': [{'hoge': {'foo': 'bar', 'ref': 'bar'}}]
+            },
+            {
+                # The case malformed key is in a internal list value.
+                'raw': [{'fuga': [{'foo': 'bar'}, {'_ref': 'bar'}]}],
+                'exp': [{'fuga': [{'foo': 'bar'}, {'ref': 'bar'}]}]
+            },
+            {
+                # The case '_ref' string values in a list, these are harmless.
+                'raw': [{'fuga': ['_ref', 'foo']}, '_ref'],
+                'exp': [{'fuga': ['_ref', 'foo']}, '_ref'],
+            }
+        ]
+
+        for check_value in check_values:
+            with mock.patch('lib.action.connector.Connector.get_object',
+                            mock.Mock(return_value=check_value['raw'])):
+
+                # This checks returned value of this action would be inspected and the one
+                # that has hamlfull key-value (which has '_ref' key) would be converted
+                # to harmless value as expected.
+                self.assertEqual(action.run(object_type='record:a'), check_value['exp'])

--- a/tests/test_action_restart_services.py
+++ b/tests/test_action_restart_services.py
@@ -13,7 +13,7 @@ class RestartServicesTestCase(InfobloxBaseActionTestCase):
 
         # This assumes that the result of get_object doens't contain reference of member
         action.connection.get_object = mock.Mock(return_value=[
-            {'_ref': 'foo'},
+            {'ref': 'foo'},
             {'result': 'invalid_data'},
             None
         ])


### PR DESCRIPTION
## Summary
The `get_object` method of `infoblox_client` returns value that has dict value which has '_ref' key. But this value is harmful for st2. This patch converts it to harmless one.

## Detail
When an action which returns this value is executed at workflow, that workflow would not be finished because an exception would be raise internally like this.
https://gist.github.com/userlocalhost/4bd50d0bcc00f18f7dd973996a1ed0e9

This is because StackStorm pass the result of this action to mongoengine, then mongoengine try to evaluate this parameter. But '_ref' value which is returned by the infoblox never be evaluated correctly, of-course.

This patch interchanges returned value of `get_object` method to harmless one for st2.