### PR TITLE
Added an action to delete specified CNAME records

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.2
+
+- Added an action to delete specified CNAME records
+
 ## 0.1.0
 
 - Initial Release of Infoblox integration

--- a/actions/delete_cnamerecord.yaml
+++ b/actions/delete_cnamerecord.yaml
@@ -1,0 +1,15 @@
+---
+name: delete_cnamerecord
+pack: infoblox
+runner_type: orquesta
+description: Delete CNAME records
+enabled: true
+entry_point: workflows/delete_cnamerecord.yaml
+parameters:
+  name:
+    type: string
+    description: Record name to be deleted
+    required: true
+  zone:
+    type: string
+    description: Filter by zone

--- a/actions/workflows/delete_cnamerecord.yaml
+++ b/actions/workflows/delete_cnamerecord.yaml
@@ -1,0 +1,33 @@
+version: 1.0
+
+input:
+  - name
+  - zone
+
+vars:
+  - stderr: ''
+
+tasks:
+  get_target_items:
+    action: infoblox.get_cnamerecord
+    input:
+      name: <% ctx(name) %>
+      zone: <% ctx(zone) %>
+    next:
+      - when: <% succeeded() and result().result %>
+        do: delete_records
+
+      - when: <% succeeded() and not result().result %>
+        publish:
+          - stderr: 'There was no object to match the condition you specified.'
+        do: fail
+
+  delete_records:
+    with: <% task(get_target_items).result.result %>
+    action: infoblox.delete_object
+    input:
+      ref: <% item().ref %>
+
+output:
+  - result: <% task(get_target_items).result %>
+  - stderr: <% ctx(stderr) %>

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: infoblox
 name: infoblox
 description: Infoblox IPAM, DNS and DHCP management
-version: 0.2.0
+version: 0.3.2
 keywords:
   - IPAM
   - DNS


### PR DESCRIPTION
This patch adds an action to delete CNAME records by using orquesta.

### Note
* This patch requires the change of #3.
* This patch requires st2 v2.10.1, or later.