### PR TITLE
Added an action metadata to update the Infoblox objects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.3.0
+- Added an action to update object (infoblox.update_object)
+
 ## 0.1.0
 
 - Initial Release of Infoblox integration

--- a/actions/update_object.py
+++ b/actions/update_object.py
@@ -1,3 +1,4 @@
+from infoblox_client import exceptions
 from lib.action import InfobloxBaseAction
 
 __all__ = [
@@ -6,10 +7,15 @@ __all__ = [
 
 
 class UpdateObjectAction(InfobloxBaseAction):
-    def run(self, ref, **kwargs):
-        _keys = list(kwargs.keys())
+    def run(self, ref, payload):
+        _keys = list(payload.keys())
         for k in _keys:
-            if kwargs[k] is None:
-                del kwargs[k]
-        result = self.connection.update_object(ref, kwargs)
-        return result
+            if payload[k] is None:
+                del payload[k]
+
+        try:
+            result = self.connection.update_object(ref, payload)
+        except exceptions.InfobloxException as e:
+            return (False, e)
+
+        return (True, result)

--- a/actions/update_object.yaml
+++ b/actions/update_object.yaml
@@ -1,0 +1,15 @@
+---
+name: update_object
+runner_type: python-script
+description: Update an object
+enabled: true
+entry_point: update_object.py
+parameters:
+  ref:
+    type: string
+    required: true
+    description: The infoblox object reference ID
+  payload:
+    type: object
+    required: true
+    description: Payload with data to send to the Infoblox

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: infoblox
 name: infoblox
 description: Infoblox IPAM, DNS and DHCP management
-version: 0.2.0
+version: 0.3.0
 keywords:
   - IPAM
   - DNS

--- a/tests/test_action_update_object.py
+++ b/tests/test_action_update_object.py
@@ -1,0 +1,40 @@
+import mock
+
+from infoblox_client import exceptions
+from tests.lib.action import InfobloxBaseActionTestCase
+from update_object import UpdateObjectAction
+
+
+class UpdateObjectTestCase(InfobloxBaseActionTestCase):
+    __test__ = True
+    action_cls = UpdateObjectAction
+
+    def test_update_object(self):
+        action = self.get_action_instance(self.full_config)
+
+        def side_effect(ref, payload):
+            return payload
+        action.connection.update_object = mock.Mock(side_effect=side_effect)
+
+        # run action and check expected values are returned
+        (is_success, result) = action.run('ref', {'hoge': 'fuga', 'foo': None})
+        self.assertTrue(is_success)
+        self.assertEqual(result, {'hoge': 'fuga'})
+
+    def test_update_object_with_cannnot_update_exception(self):
+        action = self.get_action_instance(self.full_config)
+
+        # When user specifies invalid ref value, infoblox-client raises
+        # InfobloxCannotUpdateObject exception.
+        def side_effect(ref, payload):
+            raise exceptions.InfobloxCannotUpdateObject(**{
+                'response': {'result': 'fail'},
+                'ref': ref,
+                'content': 'hoge',
+                'code': 400
+            })
+        action.connection.update_object = mock.Mock(side_effect=side_effect)
+
+        (is_success, result) = action.run('ref', {'hoge': 'fuga', 'foo': None})
+        self.assertFalse(is_success)
+        self.assertEqual(str(result), 'Cannot update object with ref ref: hoge [code 400]')


### PR DESCRIPTION
## Summary
This patch adds action metadata to update the any type of Infoblox object

## Detail
While there was an implementation to update object `update_object.py`, there was no action metadata.
This patch adds action metadata to utilize this implementation.

And this changes argument of this implementation to be able to send predetermined parameter to each type of Infoblox objects through 'payload' parameter.
