### PR TITLE
Fixed typo in the get_authzone action metadata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.1
+
+- Fixed typo of action get_authzone (changed action name from get_authuone to get_authzone)
+
 ## 0.1.0
 
 - Initial Release of Infoblox integration

--- a/actions/get_authzone.yaml
+++ b/actions/get_authzone.yaml
@@ -1,5 +1,5 @@
 ---
-name: get_authuone
+name: get_authzone
 runner_type: python-script
 description: Get authoritative zones
 enabled: true

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: infoblox
 name: infoblox
 description: Infoblox IPAM, DNS and DHCP management
-version: 0.2.0
+version: 0.2.1
 keywords:
   - IPAM
   - DNS


### PR DESCRIPTION
This changed action name from `get_authuone` to `get_authzone` in [get_authzone.yaml](https://github.com/StackStorm-Exchange/stackstorm-infoblox/blob/master/actions/get_authzone.yaml).