### PR TITLE
Enhanced actions to be able to do CRUD operations for DNS.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.1
+
+- Fixed typo of action get_authzone (changed action name from get_authuone to get_authzone)
+
 ## 0.1.0
 
 - Initial Release of Infoblox integration

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.1
+
+- Added an action to delete specified A records
+
 ## 0.1.0
 
 - Initial Release of Infoblox integration

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.0
+
+- Updated returned value format of get_action method from `_ref` to `ref`.
+
 ## 0.1.0
 
 - Initial Release of Infoblox integration

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.2
+
+- Added an action to delete specified CNAME records
+
 ## 0.1.0
 
 - Initial Release of Infoblox integration

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.3.0
+- Added an action to update object (infoblox.update_object)
+
 ## 0.1.0
 
 - Initial Release of Infoblox integration

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@
 - Fixed typo of action get_authzone (changed action name from get_authuone to get_authzone)
 - Updated returned value format of get_action method from `_ref` to `ref`.
 
+## 0.2.0
+
+- Added an action to add Authoritative Zone for DNS
+- Added an action to restart all member services
+
 ## 0.1.0
 
 - Initial Release of Infoblox integration

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,14 @@
 
 ## 0.3.0
 
-- Updated returned value format of get_action method from `_ref` to `ref`.
-- Added an action to delete specified A records
-- Added an action to delete specified CNAME records
+- Added an action to delete specified A records of DNS
+- Added an action to delete specified CNAME records of DNS
+- Added an action to delete specified authoritative zone object of DNS
+- Added an action to update A records of DNS
+- Added an action to update CNAME records of DNS
 - Added an action to update object (infoblox.update_object)
 - Fixed typo of action get_authzone (changed action name from get_authuone to get_authzone)
+- Updated returned value format of get_action method from `_ref` to `ref`.
 
 ## 0.1.0
 

--- a/actions/delete_arecord.yaml
+++ b/actions/delete_arecord.yaml
@@ -1,0 +1,18 @@
+---
+name: delete_arecord
+pack: infoblox
+runner_type: orquesta
+description: Delete A Records
+entry_point: workflows/delete_arecord.yaml
+enabled: true
+parameters:
+  ipv4addr:
+    type: string
+    description: Filter by IPv4 address
+  name: 
+    type: string
+    description: Record name to be deleted
+    required: true
+  view:
+    type: string
+    description: Filter by DNS view

--- a/actions/delete_cnamerecord.yaml
+++ b/actions/delete_cnamerecord.yaml
@@ -1,0 +1,15 @@
+---
+name: delete_cnamerecord
+pack: infoblox
+runner_type: orquesta
+description: Delete CNAME records
+enabled: true
+entry_point: workflows/delete_cnamerecord.yaml
+parameters:
+  name:
+    type: string
+    description: Record name to be deleted
+    required: true
+  zone:
+    type: string
+    description: Filter by zone

--- a/actions/delete_dns_auth_zone.yaml
+++ b/actions/delete_dns_auth_zone.yaml
@@ -1,0 +1,12 @@
+---
+name: delete_dns_auth_zone
+pack: infoblox
+runner_type: orquesta
+description: Delete an authoritative zone for DNS
+entry_point: workflows/delete_dns_auth_zone.yaml
+enabled: true
+parameters:
+  fqdn: 
+    type: string
+    description: The name of deleting DNS zone
+    required: true

--- a/actions/get_authzone.yaml
+++ b/actions/get_authzone.yaml
@@ -1,5 +1,5 @@
 ---
-name: get_authuone
+name: get_authzone
 runner_type: python-script
 description: Get authoritative zones
 enabled: true

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -41,10 +41,14 @@ class InfobloxConnector(connector.Connector):
         The original method returns dict value that st2 doens't take care (e.g. '_ref'
         key-value pairs). This method interchanges this key to another harmless one.
         """
-        # The get_object method of infoblox-client returns list of Infoblox objects
         results = super(InfobloxConnector, self).get_object(*args, **kwargs)
 
-        return [self._inspect_and_interchane_dict(x) for x in results]
+        # The get_object method of infoblox-client returns list of Infoblox objects.
+        # But when there is no Infoblox object to be returned, this method returns None.
+        if isinstance(results, list):
+            return [self._inspect_and_interchane_dict(x) for x in results]
+        else:
+            return results
 
 
 class InfobloxBaseAction(Action):

--- a/actions/restart_services.py
+++ b/actions/restart_services.py
@@ -9,9 +9,9 @@ class RestartAllMemberServicesAction(InfobloxBaseAction):
     def run(self):
         return [self.connection.call_func(**{
             'func_name': 'restartservices',
-            'ref': x['_ref'],
+            'ref': x['ref'],
             'payload': {
                 'restart_option': 'RESTART_IF_NEEDED',
                 'service_option': 'ALL'
             }
-        }) for x in self.connection.get_object('member') if x and '_ref' in x]
+        }) for x in self.connection.get_object('member') if x and 'ref' in x]

--- a/actions/update_arecord.yaml
+++ b/actions/update_arecord.yaml
@@ -1,0 +1,24 @@
+---
+name: update_arecord
+pack: infoblox
+runner_type: orquesta
+description: Update A Records
+entry_point: workflows/update_arecord.yaml
+enabled: true
+parameters:
+  ipv4addr:
+    type: string
+    description: Filter by IPv4 address
+  name: 
+    type: string
+    description: Filter by record name to be updated
+    required: true
+  view:
+    type: string
+    description: Filter by DNS view
+  updating_ipv4addr:
+    type: string
+    description: IPv4 address after updating
+  updating_name: 
+    type: string
+    description: Record name after updating

--- a/actions/update_cnamerecord.yaml
+++ b/actions/update_cnamerecord.yaml
@@ -1,0 +1,21 @@
+---
+name: update_cnamerecord
+pack: infoblox
+runner_type: orquesta
+description: Update CNAME Records
+entry_point: workflows/update_cnamerecord.yaml
+enabled: true
+parameters:
+  zone:
+    type: string
+    description: Filter by zone name to be updated
+  name: 
+    type: string
+    description: Filter by record name to be updated
+    required: true
+  updating_canonical:
+    type: string
+    description: Canonical record name after updating
+  updating_name: 
+    type: string
+    description: Record name after updating

--- a/actions/update_object.py
+++ b/actions/update_object.py
@@ -1,3 +1,4 @@
+from infoblox_client import exceptions
 from lib.action import InfobloxBaseAction
 
 __all__ = [
@@ -6,10 +7,15 @@ __all__ = [
 
 
 class UpdateObjectAction(InfobloxBaseAction):
-    def run(self, ref, **kwargs):
-        _keys = list(kwargs.keys())
+    def run(self, ref, payload):
+        _keys = list(payload.keys())
         for k in _keys:
-            if kwargs[k] is None:
-                del kwargs[k]
-        result = self.connection.update_object(ref, kwargs)
-        return result
+            if payload[k] is None:
+                del payload[k]
+
+        try:
+            result = self.connection.update_object(ref, payload)
+        except exceptions.InfobloxException as e:
+            return (False, e)
+
+        return (True, result)

--- a/actions/update_object.yaml
+++ b/actions/update_object.yaml
@@ -1,0 +1,15 @@
+---
+name: update_object
+runner_type: python-script
+description: Update an object
+enabled: true
+entry_point: update_object.py
+parameters:
+  ref:
+    type: string
+    required: true
+    description: The infoblox object reference ID
+  payload:
+    type: object
+    required: true
+    description: Payload with data to send to the Infoblox

--- a/actions/workflows/delete_arecord.yaml
+++ b/actions/workflows/delete_arecord.yaml
@@ -1,0 +1,35 @@
+version: 1.0
+
+input:
+  - ipv4addr
+  - name
+  - view
+
+vars:
+  - stderr: ''
+
+tasks:
+  get_target_items:
+    action: infoblox.get_arecord
+    input:
+      ipv4addr: <% ctx(ipv4addr) %>
+      name: <% ctx(name) %>
+      view: <% ctx(view) %>
+    next:
+      - when: <% succeeded() and result().result %>
+        do: delete_records
+
+      - when: <% succeeded() and not result().result %>
+        publish:
+          - stderr: 'There was no object to match the condition you specified.'
+        do: fail
+
+  delete_records:
+    with: <% task(get_target_items).result.result %>
+    action: infoblox.delete_object
+    input:
+      ref: <% item().ref %>
+
+output:
+  - result: <% task(get_target_items).result %>
+  - stderr: <% ctx(stderr) %>

--- a/actions/workflows/delete_cnamerecord.yaml
+++ b/actions/workflows/delete_cnamerecord.yaml
@@ -1,0 +1,33 @@
+version: 1.0
+
+input:
+  - name
+  - zone
+
+vars:
+  - stderr: ''
+
+tasks:
+  get_target_items:
+    action: infoblox.get_cnamerecord
+    input:
+      name: <% ctx(name) %>
+      zone: <% ctx(zone) %>
+    next:
+      - when: <% succeeded() and result().result %>
+        do: delete_records
+
+      - when: <% succeeded() and not result().result %>
+        publish:
+          - stderr: 'There was no object to match the condition you specified.'
+        do: fail
+
+  delete_records:
+    with: <% task(get_target_items).result.result %>
+    action: infoblox.delete_object
+    input:
+      ref: <% item().ref %>
+
+output:
+  - result: <% task(get_target_items).result %>
+  - stderr: <% ctx(stderr) %>

--- a/actions/workflows/delete_dns_auth_zone.yaml
+++ b/actions/workflows/delete_dns_auth_zone.yaml
@@ -1,0 +1,31 @@
+version: 1.0
+
+input:
+  - fqdn
+
+vars:
+  - stderr: ''
+
+tasks:
+  get_target_items:
+    action: infoblox.get_authzone
+    input:
+      fqdn: <% ctx(fqdn) %>
+    next:
+      - when: <% succeeded() and result().result %>
+        do: delete_records
+
+      - when: <% succeeded() and not result().result %>
+        publish:
+          - stderr: 'There was no object to match the condition you specified.'
+        do: fail
+
+  delete_records:
+    with: <% task(get_target_items).result.result %>
+    action: infoblox.delete_object
+    input:
+      ref: <% item().ref %>
+
+output:
+  - result: <% task(get_target_items).result %>
+  - stderr: <% ctx(stderr) %>

--- a/actions/workflows/update_arecord.yaml
+++ b/actions/workflows/update_arecord.yaml
@@ -1,0 +1,40 @@
+version: 1.0
+
+input:
+  - ipv4addr
+  - name
+  - view
+  - updating_ipv4addr
+  - updating_name
+
+vars:
+  - stderr: ''
+
+tasks:
+  get_target_items:
+    action: infoblox.get_arecord
+    input:
+      ipv4addr: <% ctx(ipv4addr) %>
+      name: <% ctx(name) %>
+      view: <% ctx(view) %>
+    next:
+      - when: <% succeeded() and result().result %>
+        do: update_records
+
+      - when: <% succeeded() and not result().result %>
+        publish:
+          - stderr: 'There was no object to match the condition you specified.'
+        do: fail
+
+  update_records:
+    with: <% task(get_target_items).result.result %>
+    action: infoblox.update_object
+    input:
+      ref: <% item().ref %>
+      payload:
+        ipv4addr: <% ctx(updating_ipv4addr) %>
+        name: <% ctx(updating_name) %>
+
+output:
+  - result: <% task(update_records).result %>
+  - stderr: <% ctx(stderr) %>

--- a/actions/workflows/update_cnamerecord.yaml
+++ b/actions/workflows/update_cnamerecord.yaml
@@ -1,0 +1,39 @@
+version: 1.0
+
+input:
+  - name
+  - zone
+  - updating_canonical
+  - updating_name
+
+vars:
+  - stderr: ''
+
+tasks:
+  get_target_items:
+    action: infoblox.get_cnamerecord
+    input:
+      name: <% ctx(name) %>
+      zone: <% ctx(zone) %>
+    next:
+      - when: <% succeeded() and result().result %>
+        do: update_records
+
+      - when: <% succeeded() and not result().result %>
+        publish:
+          - stderr: 'There was no object to match the condition you specified.'
+        do: fail
+
+  update_records:
+    with: <% task(get_target_items).result.result %>
+    action: infoblox.update_object
+    input:
+      ref: <% item().ref %>
+      payload:
+        canonical: <% ctx(updating_canonical) %>
+        name: <% ctx(updating_name) %>
+
+output:
+  - result: <% task(update_records).result %>
+  - stderr: <% ctx(stderr) %>
+

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: infoblox
 name: infoblox
 description: Infoblox IPAM, DNS and DHCP management
-version: 0.2.0
+version: 0.3.1
 keywords:
   - IPAM
   - DNS

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: infoblox
 name: infoblox
 description: Infoblox IPAM, DNS and DHCP management
-version: 1.0.0
+version: 0.3.0
 keywords:
   - IPAM
   - DNS

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: infoblox
 name: infoblox
 description: Infoblox IPAM, DNS and DHCP management
-version: 0.2.0
+version: 0.3.0
 keywords:
   - IPAM
   - DNS

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: infoblox
 name: infoblox
 description: Infoblox IPAM, DNS and DHCP management
-version: 0.2.0
+version: 1.0.0
 keywords:
   - IPAM
   - DNS

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: infoblox
 name: infoblox
 description: Infoblox IPAM, DNS and DHCP management
-version: 0.2.0
+version: 0.3.2
 keywords:
   - IPAM
   - DNS

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: infoblox
 name: infoblox
 description: Infoblox IPAM, DNS and DHCP management
-version: 0.2.0
+version: 0.2.1
 keywords:
   - IPAM
   - DNS

--- a/tests/test_action_get_object.py
+++ b/tests/test_action_get_object.py
@@ -30,6 +30,11 @@ class GetObjectTestCase(InfobloxBaseActionTestCase):
                 # The case '_ref' string values in a list, these are harmless.
                 'raw': [{'fuga': ['_ref', 'foo']}, '_ref'],
                 'exp': [{'fuga': ['_ref', 'foo']}, '_ref'],
+            },
+            {
+                # The case non-list value is returned.
+                'raw': None,
+                'exp': None,
             }
         ]
 

--- a/tests/test_action_get_object.py
+++ b/tests/test_action_get_object.py
@@ -1,0 +1,43 @@
+import mock
+
+from get_object import GetObjectAction
+from tests.lib.action import InfobloxBaseActionTestCase
+
+
+class GetObjectTestCase(InfobloxBaseActionTestCase):
+    __test__ = True
+    action_cls = GetObjectAction
+
+    def test_get_object_that_has_malformed_value(self):
+        action = self.get_action_instance(self.full_config)
+        check_values = [
+            {
+                # The case malformed key is in a top level dict value.
+                'raw': [{'foo': 'bar', '_ref': 'foo'}, {'hoge': 'fuga'}],
+                'exp': [{'foo': 'bar', 'ref': 'foo'}, {'hoge': 'fuga'}]
+            },
+            {
+                # The case malformed key is in a internal dict value.
+                'raw': [{'hoge': {'foo': 'bar', '_ref': 'bar'}}],
+                'exp': [{'hoge': {'foo': 'bar', 'ref': 'bar'}}]
+            },
+            {
+                # The case malformed key is in a internal list value.
+                'raw': [{'fuga': [{'foo': 'bar'}, {'_ref': 'bar'}]}],
+                'exp': [{'fuga': [{'foo': 'bar'}, {'ref': 'bar'}]}]
+            },
+            {
+                # The case '_ref' string values in a list, these are harmless.
+                'raw': [{'fuga': ['_ref', 'foo']}, '_ref'],
+                'exp': [{'fuga': ['_ref', 'foo']}, '_ref'],
+            }
+        ]
+
+        for check_value in check_values:
+            with mock.patch('lib.action.connector.Connector.get_object',
+                            mock.Mock(return_value=check_value['raw'])):
+
+                # This checks returned value of this action would be inspected and the one
+                # that has hamlfull key-value (which has '_ref' key) would be converted
+                # to harmless value as expected.
+                self.assertEqual(action.run(object_type='record:a'), check_value['exp'])

--- a/tests/test_action_restart_services.py
+++ b/tests/test_action_restart_services.py
@@ -13,7 +13,7 @@ class RestartServicesTestCase(InfobloxBaseActionTestCase):
 
         # This assumes that the result of get_object doens't contain reference of member
         action.connection.get_object = mock.Mock(return_value=[
-            {'_ref': 'foo'},
+            {'ref': 'foo'},
             {'result': 'invalid_data'},
             None
         ])

--- a/tests/test_action_update_object.py
+++ b/tests/test_action_update_object.py
@@ -1,0 +1,40 @@
+import mock
+
+from infoblox_client import exceptions
+from tests.lib.action import InfobloxBaseActionTestCase
+from update_object import UpdateObjectAction
+
+
+class UpdateObjectTestCase(InfobloxBaseActionTestCase):
+    __test__ = True
+    action_cls = UpdateObjectAction
+
+    def test_update_object(self):
+        action = self.get_action_instance(self.full_config)
+
+        def side_effect(ref, payload):
+            return payload
+        action.connection.update_object = mock.Mock(side_effect=side_effect)
+
+        # run action and check expected values are returned
+        (is_success, result) = action.run('ref', {'hoge': 'fuga', 'foo': None})
+        self.assertTrue(is_success)
+        self.assertEqual(result, {'hoge': 'fuga'})
+
+    def test_update_object_with_cannnot_update_exception(self):
+        action = self.get_action_instance(self.full_config)
+
+        # When user specifies invalid ref value, infoblox-client raises
+        # InfobloxCannotUpdateObject exception.
+        def side_effect(ref, payload):
+            raise exceptions.InfobloxCannotUpdateObject(**{
+                'response': {'result': 'fail'},
+                'ref': ref,
+                'content': 'hoge',
+                'code': 400
+            })
+        action.connection.update_object = mock.Mock(side_effect=side_effect)
+
+        (is_success, result) = action.run('ref', {'hoge': 'fuga', 'foo': None})
+        self.assertFalse(is_success)
+        self.assertEqual(str(result), 'Cannot update object with ref ref: hoge [code 400]')


### PR DESCRIPTION
## Summary

This PR integrates previous miscellaneous PRs to be able to do CRUD operations for DNS objects.

## Changes

- Added an action to delete specified A records of DNS (#4)
- Added an action to delete specified CNAME records of DNS (#5)
- Added an action to delete specified authoritative zone object of DNS
- Added an action to update A records of DNS
- Added an action to update CNAME records of DNS
- Added an action to update object (infoblox.update_object) (#6)
- Fixed typo of action get_authzone (changed action name from get_authuone to get_authzone) (#7)
- Updated returned value format of get_action method from `_ref` to `ref`. (#3)