### PR TITLE
Added actions to do CRUD operations of HOST records for DNS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.4.0
+
+- Added an action to create a HOST record for DNS
+- Added an action to delete HOST records for DNS
+- Added an action to update HOST records for DNS
+- Added some parameters to the `get_hostrecord` action to filter the results (This change has backward compatibility)
+- Refactored implementation of the `create_object` action for adding an error handler
+
 ## 0.3.0
 
 - Added an action to delete specified A records of DNS

--- a/actions/create_hostrecord.yaml
+++ b/actions/create_hostrecord.yaml
@@ -1,0 +1,35 @@
+---
+name: create_hostrecord
+pack: infoblox
+runner_type: python-script
+description: Create a Host record
+enabled: true
+entry_point: create_object.py
+parameters:
+  object_type:
+    type: string
+    immutable: true
+    default: 'record:host'
+  name:
+    type: string
+    required: true
+    description: The name of creating host record
+  view:
+    type: string
+    description: Filter by DNS view
+  ttl:
+    type: integer
+    default: 28800
+    description: TTL of creating record
+  ipv4addrs:
+    type: array
+    description: IPv4 address informations to register the creating host record
+    properties:
+      mac:
+        type: string
+        description: MAC address to register
+        default: ''
+      ipv4addr:
+        type: string
+        required: true
+        description: IPv4 address to register

--- a/actions/create_object.py
+++ b/actions/create_object.py
@@ -1,3 +1,4 @@
+from infoblox_client import exceptions
 from lib.action import InfobloxBaseAction
 
 __all__ = [
@@ -7,5 +8,7 @@ __all__ = [
 
 class CreateObjectAction(InfobloxBaseAction):
     def run(self, object_type, **kwargs):
-        result = self.connection.create_object(object_type, kwargs)
-        return result
+        try:
+            return (True, self.connection.create_object(object_type, kwargs))
+        except exceptions.InfobloxCannotCreateObject as e:
+            return (False, e.response)

--- a/actions/delete_hostrecord.yaml
+++ b/actions/delete_hostrecord.yaml
@@ -1,0 +1,15 @@
+---
+name: delete_hostrecord
+pack: infoblox
+runner_type: orquesta
+description: Delete HOST Records
+entry_point: workflows/delete_hostrecord.yaml
+enabled: true
+parameters:
+  name: 
+    type: string
+    description: Record name to be deleted
+    required: true
+  view:
+    type: string
+    description: Filter by DNS view

--- a/actions/get_hostrecord.yaml
+++ b/actions/get_hostrecord.yaml
@@ -1,7 +1,8 @@
 ---
 name: get_hostrecord
+pack: infoblox
 runner_type: python-script
-description: Get host records
+description: Get HOST records
 enabled: true
 entry_point: get_object.py
 parameters:
@@ -9,6 +10,12 @@ parameters:
     type: string
     immutable: true
     default: 'record:host'
+  name:
+    type: string
+    description: Filter by name of HOST record
+  view:
+    type: string
+    description: Filter by DNS view
   ea:
     type: array
     description: "Example: ['IN_Country=FR','IN_DeviceType=AGGREG']"

--- a/actions/update_hostrecord.yaml
+++ b/actions/update_hostrecord.yaml
@@ -1,0 +1,34 @@
+---
+name: update_hostrecord
+pack: infoblox
+runner_type: orquesta
+description: Update HOST records
+enabled: true
+entry_point: workflows/update_hostrecord.yaml
+parameters:
+  name:
+    type: string
+    required: true
+    description: The name of HOST record to update
+  updating_name:
+    type: string
+    description: The name of HOST record after update
+  view:
+    type: string
+    description: Filter by DNS view
+  ttl:
+    type: integer
+    default: 28800
+    description: TTL of updating record
+  ipv4addrs:
+    type: array
+    description: IPv4 address informations to update
+    properties:
+      mac:
+        type: string
+        description: MAC address to register
+        default: ''
+      ipv4addr:
+        type: string
+        required: true
+        description: IPv4 address to register

--- a/actions/workflows/delete_hostrecord.yaml
+++ b/actions/workflows/delete_hostrecord.yaml
@@ -1,0 +1,33 @@
+version: 1.0
+
+input:
+  - name
+  - view
+
+vars:
+  - stderr: ''
+
+tasks:
+  get_target_items:
+    action: infoblox.get_hostrecord
+    input:
+      name: <% ctx(name) %>
+      view: <% ctx(view) %>
+    next:
+      - when: <% succeeded() and result().result %>
+        do: delete_records
+
+      - when: <% succeeded() and not result().result %>
+        publish:
+          - stderr: 'There was no object to match the condition you specified.'
+        do: fail
+
+  delete_records:
+    with: <% task(get_target_items).result.result %>
+    action: infoblox.delete_object
+    input:
+      ref: <% item().ref %>
+
+output:
+  - result: <% task(get_target_items).result %>
+  - stderr: <% ctx(stderr) %>

--- a/actions/workflows/update_hostrecord.yaml
+++ b/actions/workflows/update_hostrecord.yaml
@@ -1,0 +1,45 @@
+version: 1.0
+
+input:
+  - name
+  - updating_name
+  - view
+  - ttl
+  - ipv4addrs
+
+vars:
+  - stderr:
+  - result:
+
+tasks:
+  get_target_items:
+    action: infoblox.get_hostrecord
+    input:
+      name: <% ctx(name) %>
+      view: <% ctx(view) %>
+    next:
+      - when: <% succeeded() and result().result %>
+        do: update_records
+
+      - when: <% succeeded() and not result().result %>
+        publish:
+          - stderr: 'There was no object to match the condition you specified.'
+        do: fail
+
+  update_records:
+    with: <% task(get_target_items).result.result %>
+    action: infoblox.update_object
+    input:
+      ref: <% item().ref %>
+      payload:
+        ttl: <% ctx(ttl) %>
+        ipv4addrs: <% ctx(ipv4addrs) %>
+        name: <% ctx(updating_name) %>
+    next:
+      - when: <% succeeded() %>
+        publish:
+          - result: <% result() %>
+
+output:
+  - result: <% ctx(result) %>
+  - stderr: <% ctx(stderr) %>

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: infoblox
 name: infoblox
 description: Infoblox IPAM, DNS and DHCP management
-version: 0.3.0
+version: 0.4.0
 keywords:
   - IPAM
   - DNS

--- a/tests/test_action_create_object.py
+++ b/tests/test_action_create_object.py
@@ -1,0 +1,38 @@
+import mock
+
+from create_object import CreateObjectAction
+from infoblox_client import exceptions
+from tests.lib.action import InfobloxBaseActionTestCase
+
+
+class CreateObjectTestCase(InfobloxBaseActionTestCase):
+    __test__ = True
+    action_cls = CreateObjectAction
+
+    def test_create_object(self):
+        action = self.get_action_instance(self.full_config)
+
+        action.connection = mock.Mock()
+        action.connection.create_object.return_value = 'result'
+
+        (is_success, value) = action.run(object_type='record:host', name='name', ipv4addrs=[])
+        self.assertTrue(is_success)
+        self.assertEqual(value, 'result')
+
+    def test_create_object_with_exception(self):
+        action = self.get_action_instance(self.full_config)
+
+        def side_effect(*args, **kwargs):
+            raise exceptions.InfobloxCannotCreateObject(
+                response={'Error': 'Message'},
+                obj_type='object_type',
+                content='hoge',
+                args={},
+                code=400)
+
+        action.connection = mock.Mock()
+        action.connection.create_object.side_effect = side_effect
+
+        (is_success, value) = action.run(object_type='record:host', name='name', ipv4addrs=[])
+        self.assertFalse(is_success)
+        self.assertEqual(value, {'Error': 'Message'})


### PR DESCRIPTION
This patch added (or updated) actions involved with HOST records for DNS as below.

- Added an action to create a HOST record for DNS
- Added an action to delete HOST records for DNS
- Added an action to update HOST records for DNS
- Added some parameters to the `get_hostrecord` action to filter the results
  (This change has backward compatibility)
- Refactored implementation of the `create_object` action for adding an error handler