### PR TITLE
Add WAPI version variable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.1.0
+
+- Added WAPI version variable to config schema
+  
 ## 1.0.0
 
 * Drop Python 2.7 support

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -15,6 +15,12 @@
     type: "string"
     secret: false
     required: true
+  wapi_version:
+    description: "Hostname of Infloblox"
+    type: "string"
+    secret: false
+    required: false
+    default: "v2.9"
   verify_ssl:
     description: "Verify SSL of Infoblox API"
     default: true

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -16,7 +16,7 @@
     secret: false
     required: true
   wapi_version:
-    description: "Hostname of Infloblox"
+    description: "Wapi version of Infoblox"
     type: "string"
     secret: false
     required: false

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: infoblox
 name: infoblox
 description: Infoblox IPAM, DNS and DHCP management
-version: 1.0.0
+version: 1.1.0
 keywords:
   - IPAM
   - DNS


### PR DESCRIPTION
The infoblox-client supports WAPI version specification but the current config.schema.yaml doesn't specify it.
This pull request is to make is adjustable from the StackStrom UI and update it to v2.9 by default.